### PR TITLE
Remove duplicate cfg_attr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,6 @@
     intra_doc_link_resolution_failure,
     broken_intra_doc_links
 )]
-// These little nifty labels saying that something needs a feature to be enabled
-#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Library for easier and safe Unix signal handling
 //!
 //! Unix signals are inherently hard to handle correctly, for several reasons:


### PR DESCRIPTION
This commit removes the duplicate cfg_attr that leads to docs.rs build
failing.

Signed-off-by: Ionut Mihalcea <ionut@mihalcea.dev>